### PR TITLE
Fix for redmine 2.2.0

### DIFF
--- a/lib/wiki_notes_macros.rb
+++ b/lib/wiki_notes_macros.rb
@@ -10,28 +10,28 @@ module WikiNotesMacro
       o = '<div class="noteclassic">'
       o << args.join(",")
       o << '</div>'
-      o
+      o.html_safe
     end
 
     macro :tip do |obj, args|
       o = '<div class="notetip">'
       o << args.join(",")
       o << '</div>'
-      o
+      o.html_safe
     end
 
     macro :important do |obj, args|
       o = '<div class="noteimportant">'
       o << args.join(",")
       o << '</div>'
-      o
+      o.html_safe
     end
 
     macro :warning do |obj, args|
       o = '<div class="notewarning">'
       o << args.join(",")
       o << '</div>'
-      o
+      o.html_safe
     end
   end
 end


### PR DESCRIPTION
Redmine >= 2.2.0 was escaping html tags generated by macros.
