### PR TITLE
allow multiline content for the macros

### DIFF
--- a/lib/wiki_notes_macros.rb
+++ b/lib/wiki_notes_macros.rb
@@ -6,30 +6,30 @@ module WikiNotesMacro
       " @!{{important(text)}}@\n"
       " @!{{warning(text)}}@\n"
 
-    macro :note, :parse_args => false do |obj, args|
+    macro :note, :parse_args => false do |obj, args, text|
       o = '<div class="noteclassic">'
-      o << textilizable(args)
+      o << textilizable(text)
       o << '</div>'
       o.html_safe
     end
 
-    macro :tip, :parse_args => false do |obj, args|
+    macro :tip, :parse_args => false do |obj, args, text|
       o = '<div class="notetip">'
-      o << textilizable(args)
+      o << textilizable(text)
       o << '</div>'
       o.html_safe
     end
 
-    macro :important, :parse_args => false do |obj, args|
+    macro :important, :parse_args => false do |obj, args, text|
       o = '<div class="noteimportant">'
-      o << textilizable(args)
+      o << textilizable(text)
       o << '</div>'
       o.html_safe
     end
 
-    macro :warning, :parse_args => false do |obj, args|
+    macro :warning, :parse_args => false do |obj, args, text|
       o = '<div class="notewarning">'
-      o << textilizable(args)
+      o << textilizable(text)
       o << '</div>'
       o.html_safe
     end


### PR DESCRIPTION
Previously you could not do multiline content. Now you can. Before the syntax was

{{tip(the content)}}

Now the syntax is

{{tip
the content
and there can be
many lines
}}

(Caveat: the old way is not supported after this patch. If that is a dealbreaker, it could still be supported by using whichever of args or text is non-empty)
