### PR TITLE
Added support for text blocks with wiki formatting.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -21,9 +21,21 @@ begin
   rescue LoadError
 end
 
-Dir::foreach(File.join(File.dirname(__FILE__), 'lib')) do |file|
-  next unless /\.rb$/ =~ file
-  require file
+def init_redmine_wiki_notes
+  Dir::foreach(File.join(File.dirname(__FILE__), 'lib')) do |file|
+    next unless /\.rb$/ =~ file
+    require_dependency file
+  end
+end
+
+if Rails::VERSION::MAJOR >= 3
+  ActionDispatch::Callbacks.to_prepare do
+    init_redmine_wiki_notes
+  end
+else
+  Dispatcher.to_prepare :redmine_wiki_notes do
+    init_redmine_wiki_notes
+  end
 end
 
 require 'redcloth3'

--- a/lib/wiki_notes_macros.rb
+++ b/lib/wiki_notes_macros.rb
@@ -1,37 +1,45 @@
 module WikiNotesMacro
   Redmine::WikiFormatting::Macros.register do
     desc "Adds a note to the wiki page:\n\n" +
-      " @!{{note(text)}}@\n" +
-      " @!{{tip(text)}}@\n" +
-      " @!{{important(text)}}@\n"
-      " @!{{warning(text)}}@\n"
-
-    macro :note, :parse_args => false do |obj, args|
-      o = '<div class="noteclassic">'
-      o << textilizable(args)
-      o << '</div>'
-      o.html_safe
+      "<pre>\n" +
+      "{{note(text with *wiki formatting*)}}\n" +
+      "{{note\nAlternately, you can put blocks of *wiki-formatted* text here.\n}}\n" +
+      "{{note(Or if you really want)\nYou can do both...\n}}\n" +
+      "</pre>"
+    macro :note, :parse_args => false do |obj, args, text|
+      o = textilizable(args)
+      if text.present?
+        o << textilizable(text, :object => obj, :headings => false)
+      end
+      content_tag('div', o.html_safe, :class => "noteclassic")
     end
 
-    macro :tip, :parse_args => false do |obj, args|
-      o = '<div class="notetip">'
-      o << textilizable(args)
-      o << '</div>'
-      o.html_safe
+    desc "Variant of @note@."
+    macro :tip, :parse_args => false do |obj, args, text|
+      o = textilizable(args)
+      if text.present?
+        o << textilizable(text, :object => obj, :headings => false)
+      end
+      content_tag('div', o.html_safe, :class => "notetip")
     end
 
-    macro :important, :parse_args => false do |obj, args|
-      o = '<div class="noteimportant">'
-      o << textilizable(args)
-      o << '</div>'
-      o.html_safe
+    desc "Variant of @note@."
+    macro :important, :parse_args => false do |obj, args, text|
+      o = textilizable(args)
+      if text.present?
+        o << textilizable(text, :object => obj, :headings => false)
+      end
+      content_tag('div', o.html_safe, :class => "noteimportant")
     end
 
-    macro :warning, :parse_args => false do |obj, args|
-      o = '<div class="notewarning">'
-      o << textilizable(args)
-      o << '</div>'
-      o.html_safe
+    desc "Variant of @note@."
+    macro :warning, :parse_args => false do |obj, args, text|
+      o = textilizable(args)
+      if text.present?
+        o << textilizable(text, :object => obj, :headings => false)
+      end
+      content_tag('div', o.html_safe, :class => "notewarning")
     end
   end
+
 end


### PR DESCRIPTION
This is much like the earlier pull request, except it maintains backward compatibility -- it supports args, text, or both.

I also added dispatch-based loading in the init, this is mainly to allow code changes to be applied dynamically during development but this patterns seems common in plugins so there might be other use cases.